### PR TITLE
Prevent unnecessary reinstalls in arch backend

### DIFF
--- a/src/backends/arch.rs
+++ b/src/backends/arch.rs
@@ -160,6 +160,7 @@ impl Backend for Arch {
                     config.arch_package_manager.as_command(),
                     "--sync",
                     "--asexplicit",
+                    "--needed",
                 ]
                 .into_iter()
                 .chain(Some("--no_confirm").filter(|_| no_confirm))


### PR DESCRIPTION
For whatever reason, the Arch backend will sometimes consider some packages as not properly installed and attempt to reinstall them. Adding --needed prevents this unnecessary install, functioning as a quick patch for the underlying issue.