### PR TITLE
Implement update command

### DIFF
--- a/src/backends/all.rs
+++ b/src/backends/all.rs
@@ -51,6 +51,11 @@ macro_rules! any {
                     $( AnyBackend::$upper_backend => $upper_backend::version(config), )*
                 }
             }
+            pub fn update(&self, config: &Config) -> Result<()> {
+                match self {
+                    $( AnyBackend::$upper_backend => $upper_backend::update(config), )*
+                }
+            }
         }
     };
 }

--- a/src/backends/arch.rs
+++ b/src/backends/arch.rs
@@ -220,4 +220,17 @@ impl Backend for Arch {
             false,
         )
     }
+
+    fn update(config: &Config) -> Result<()> {
+        run_command(
+            [
+                config.arch_package_manager.as_command(),
+                "--sync",
+                "--refresh",
+                "--sysupgrade",
+            ],
+            config.arch_package_manager.change_perms(),
+        )?;
+        Ok(())
+    }
 }

--- a/src/backends/flatpak.rs
+++ b/src/backends/flatpak.rs
@@ -198,4 +198,9 @@ impl Backend for Flatpak {
     fn version(_: &Config) -> Result<String> {
         run_command_for_stdout(["flatpak", "--version"], Perms::Same, false)
     }
+
+    fn update(_: &Config) -> Result<()> {
+        run_command(["flatpak", "update"], Perms::Same)?;
+        Ok(())
+    }
 }

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -65,4 +65,8 @@ pub trait Backend {
     fn clean_cache(config: &Config) -> Result<()>;
 
     fn version(config: &Config) -> Result<String>;
+
+    fn update(config: &Config) -> Result<()> {
+        color_eyre::eyre::bail!("Updating is not yet implemented for this backend")
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,6 +34,7 @@ pub enum MainSubcommand {
     Unmanaged(UnmanagedCommand),
     Backends(BackendsCommand),
     CleanCache(CleanCacheCommand),
+    Update(UpdateCommand),
 }
 
 #[derive(Args)]
@@ -136,5 +137,12 @@ pub struct BackendsCommand {}
 #[command(visible_alias("e"))]
 /// clean the caches of all the backends, or the just those specified
 pub struct CleanCacheCommand {
+    pub backends: Option<Vec<String>>,
+}
+
+#[derive(Args)]
+#[command(visible_alias("up"))]
+/// updates installed packages for all backends, or the just those specified
+pub struct UpdateCommand {
     pub backends: Option<Vec<String>>,
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -3,10 +3,9 @@ use std::fs::{self, File, read_to_string};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
+use color_eyre::Result;
 use color_eyre::eyre::{Context, ContextCompat, Ok, eyre};
-use color_eyre::{Result, eyre};
 use dialoguer::Confirm;
-use itertools::Itertools;
 use strum::IntoEnumIterator;
 use toml_edit::{Array, DocumentMut, Item, Value};
 


### PR DESCRIPTION
Closes #59

Adds a new `update` subcommand which allows the user to update all enabled backends or just the ones passed on the command line.

I've only implemented this for the arch and flatpak backends but I wanted to get this PR pushed to get your feedback.

Thanks for the great tool. I just started using it tonight and really like it coming from `pacdef`.
