### PR TITLE
Add posibility to install cargo packages with cargo-binstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added a `binstall` option to the `cargo` backend to allow using
+  `cargo-binstall` to install packages instead of `cargo install` (#165),
+  thanks @Mikel-Landa!
+
 ## [0.6.3] - 2025-10-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -308,6 +308,12 @@ quarantine = true
 # Default: false
 locked = false
 
+# Whether to use `cargo-binstall` instead of `cargo install` for installing packages.
+# When `true`, metapac will use `cargo binstall --no-confirm` instead of `cargo install`.
+# This can be faster for installing packages as it downloads pre-built binaries.
+# Default: false
+binstall = false
+
 [flatpak]
 # If this is `true` then flatpak packages default to using the `--system`
 # option.

--- a/src/backends/cargo.rs
+++ b/src/backends/cargo.rs
@@ -34,6 +34,8 @@ pub struct CargoOptions {
 pub struct CargoConfig {
     #[serde(default)]
     pub locked: bool,
+    #[serde(default)]
+    pub binstall: bool,
 }
 
 impl Backend for Cargo {
@@ -80,8 +82,14 @@ impl Backend for Cargo {
     ) -> Result<()> {
         for (package, options) in packages {
             run_command(
-                ["cargo", "install"]
+                ["cargo"]
                     .into_iter()
+                    .chain(Some("install").into_iter().filter(|_| !config.binstall))
+                    .chain(
+                        ["binstall", "--no-confirm"]
+                            .into_iter()
+                            .filter(|_| config.binstall),
+                    )
                     .chain(
                         Some("--locked")
                             .into_iter()

--- a/src/backends/cargo.rs
+++ b/src/backends/cargo.rs
@@ -84,12 +84,11 @@ impl Backend for Cargo {
             run_command(
                 ["cargo"]
                     .into_iter()
-                    .chain(Some("install").into_iter().filter(|_| !config.binstall))
-                    .chain(
-                        ["binstall", "--no-confirm"]
-                            .into_iter()
-                            .filter(|_| config.binstall),
-                    )
+                    .chain(if !config.binstall {
+                        vec!["install"]
+                    } else {
+                        vec!["binstall", "--no-confirm"]
+                    })
                     .chain(
                         Some("--locked")
                             .into_iter()


### PR DESCRIPTION
Add a toggle in the config to choose whether packages should try by default to pull the prebuilt binary if exists in cargo backend.

See: https://github.com/cargo-bins/cargo-binstall