### PR TITLE
Add mas (Mac App Store) backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New backend: `mise` (requested in #127, implemented in #166), thanks
   @Mikel-Landa!
+- New backend: `mas` (Mac App Store) (#166), thanks @jtbrough!
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ for additional backends are always welcome!
 | [`cargo`](#cargo)     |
 | [`dnf`](#dnf)         |
 | [`flatpak`](#flatpak) |
+| [`mas`](#mas)         |
 | [`mise`](#mise)       |
 | [`npm`](#npm)         |
 | [`pipx`](#pipx)       |
@@ -212,6 +213,8 @@ Reported in #152.
 ### dnf
 
 ### flatpak
+
+### mas
 
 ### mise
 

--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ flatpak = [
   "package1",
   { package = "package2", options = { remote = "flathub", systemwide = false } },
 ]
+mas = ["package1", { package = "package2" }]
 mise = [
   "package1",
   { package = "package2", options = { version = "1.0.0" } },

--- a/src/backends/mas.rs
+++ b/src/backends/mas.rs
@@ -1,0 +1,105 @@
+use color_eyre::Result;
+use color_eyre::eyre::eyre;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::cmd::{run_command, run_command_for_stdout};
+use crate::prelude::*;
+
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord, derive_more::Display)]
+pub struct Mas;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MasOptions {}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct MasConfig {}
+
+impl Backend for Mas {
+    type Options = MasOptions;
+    type Config = MasConfig;
+
+    fn invalid_package_help_text() -> String {
+        String::new()
+    }
+
+    fn is_valid_package_name(_: &str) -> Option<bool> {
+        None
+    }
+
+    fn get_all(_: &Self::Config) -> Result<BTreeSet<String>> {
+        Err(eyre!("unimplemented"))
+    }
+
+    fn get_installed(config: &Self::Config) -> Result<BTreeMap<String, Self::Options>> {
+        if Self::version(config).is_err() {
+            return Ok(BTreeMap::new());
+        }
+
+        let output = run_command_for_stdout(["mas", "list"], Perms::Same, false)?;
+
+        Ok(output
+            .lines()
+            .filter_map(|line| {
+                // Parse lines like: "425264550   Blackmagic Disk Speed Test  (3.4.2)"
+                // Extract the first field (ADAM ID) from the `mas list` output
+                line.split_whitespace()
+                    .next()
+                    .map(|app_id| (app_id.to_string(), Self::Options {}))
+            })
+            .collect())
+    }
+
+    fn install(
+        packages: &BTreeMap<String, Self::Options>,
+        _: bool,
+        _: &Self::Config,
+    ) -> Result<()> {
+        for (package, _) in packages {
+            run_command(["mas", "install", package.as_str()], Perms::Same)?;
+        }
+
+        Ok(())
+    }
+
+    fn uninstall(packages: &BTreeSet<String>, _: bool, _: &Self::Config) -> Result<()> {
+        if !packages.is_empty() {
+            run_command(
+                ["mas", "uninstall"]
+                    .into_iter()
+                    .chain(packages.iter().map(String::as_str)),
+                Perms::Sudo,
+            )?;
+        }
+
+        Ok(())
+    }
+
+    fn update(packages: &BTreeSet<String>, _: bool, _: &Self::Config) -> Result<()> {
+        if !packages.is_empty() {
+            run_command(
+                ["mas", "upgrade"]
+                    .into_iter()
+                    .chain(packages.iter().map(String::as_str)),
+                Perms::Same,
+            )?;
+        }
+
+        Ok(())
+    }
+
+    fn update_all(_: bool, _: &Self::Config) -> Result<()> {
+        run_command(["mas", "upgrade"], Perms::Same)
+    }
+
+    fn clean_cache(config: &Self::Config) -> Result<()> {
+        // mas does not provide a cache cleaning mechanism
+        Self::version(config).map(|_| ())
+    }
+
+    fn version(_: &Self::Config) -> Result<String> {
+        run_command_for_stdout(["mas", "version"], Perms::Same, false)
+    }
+}

--- a/src/backends/mas.rs
+++ b/src/backends/mas.rs
@@ -57,7 +57,7 @@ impl Backend for Mas {
         _: bool,
         _: &Self::Config,
     ) -> Result<()> {
-        for (package, _) in packages {
+        for package in packages.keys() {
             run_command(["mas", "install", package.as_str()], Perms::Same)?;
         }
 

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -6,6 +6,7 @@ pub mod bun;
 pub mod cargo;
 pub mod dnf;
 pub mod flatpak;
+pub mod mas;
 pub mod mise;
 pub mod npm;
 pub mod pipx;
@@ -33,6 +34,7 @@ macro_rules! apply_backends {
         (Cargo, cargo),
         (Dnf, dnf),
         (Flatpak, flatpak),
+        (Mas, mas),
         (Mise, mise),
         (Npm, npm),
         (Pipx, pipx),

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -12,6 +12,7 @@ pub use crate::backends::bun::{Bun, BunOptions};
 pub use crate::backends::cargo::{Cargo, CargoConfig, CargoOptions};
 pub use crate::backends::dnf::{Dnf, DnfOptions};
 pub use crate::backends::flatpak::{Flatpak, FlatpakConfig, FlatpakOptions};
+pub use crate::backends::mas::{Mas, MasConfig, MasOptions};
 pub use crate::backends::mise::{Mise, MiseConfig, MiseOptions};
 pub use crate::backends::npm::{Npm, NpmOptions};
 pub use crate::backends::pipx::{Pipx, PipxOptions};


### PR DESCRIPTION
Adds `mas` backend for managing Mac App Store apps via the [mas CLI](https://github.com/mas-cli/mas) tool.

#### Implementation:

- Implement backend methods: `list`, `install`, `uninstall`, and `upgrade`
- Parse app IDs (ADAM IDs) from mas list output
- Use `Perms::Sudo` for uninstall operations (required by mas CLI)
- Add `mas` to supported backends table in README

#### Quality:

- Did my best to follow existing backend conventions and code style patterns
- Tests passing, build succeeds, manual testing confirms functionality

#### Known Issue in `mas`:
There's currently a bug in mas version 2.3 and 3.0 affecting many operations on macOS Tahoe 26.1, actively being fixed for the upcoming 4.0 release: https://github.com/mas-cli/mas/milestone/32