### PR TITLE
Expand XDG Base Dir Spec support

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -10,6 +10,7 @@ use strum::IntoEnumIterator;
 use toml_edit::{DocumentMut, Entry, Item, Value};
 
 use crate::cli::{BackendsCommand, CleanCacheCommand};
+use crate::config::resolve_config_dir;
 use crate::prelude::*;
 
 impl MainArguments {
@@ -25,9 +26,7 @@ impl MainArguments {
         let config_dir = if let Some(x) = self.config_dir {
             x
         } else {
-            dirs::config_dir()
-                .map(|path| path.join("metapac/"))
-                .ok_or(eyre!("getting the default metapac config directory"))?
+            resolve_config_dir().wrap_err("determining the default metapac config directory")?
         };
 
         let group_dir = config_dir.join("groups/");


### PR DESCRIPTION
Expands XDG Base Dir Spec support in `metapac`, with cross-platform config path resolution with a (hopefully) sensible priority.

### Adds: `resolve_config_dir()` function
Checks config directories based on the following priority:
  1. `$XDG_CONFIG_HOME/metapac` (if set and exists)
  2. `~/.config/metapac` (if exists)
  3. Platform defaults (via dirs crate)

### Modified
- **src/config.rs**: Added `resolve_config_dir()` function with XDG support
- **src/core.rs**: Updated to call `resolve_config_dir()` instead of `dirs::config_dir()`

### Functional Tests
  - XDG_CONFIG_HOME priority verified
  - ~/.config/metapac fallback verified
  - Platform default fallback verified

### Back Compat

- Existing configs in Application Support/AppData continue to work
- Existing ~/.config/metapac installations are respected
- Only adds additional resolution paths, doesn't remove any

### Cross-Platform Support

| Platform | Behavior |
|----------|----------|
| Linux | XDG_CONFIG_HOME → ~/.config/metapac → ~/.config/metapac (via dirs) |
| macOS | XDG_CONFIG_HOME → ~/.config/metapac → ~/Library/Application Support/metapac |
| Windows | XDG_CONFIG_HOME → ~/.config/metapac → %APPDATA%/metapac |
