### PR TITLE
Fix update-all command for `pipx`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Issue with the `pipx` backend using a wrong command when updating all
+  packages, thanks @Deuchnord!
+
 ## [0.7.0] - 2025-12-13
 
 ### Added

--- a/src/backends/pipx.rs
+++ b/src/backends/pipx.rs
@@ -91,7 +91,7 @@ impl Backend for Pipx {
     }
 
     fn update_all(_: bool, _: &Self::Config) -> Result<()> {
-        run_command(["pipx", "update-all"], Perms::Same)
+        run_command(["pipx", "upgrade-all"], Perms::Same)
     }
 
     fn clean_cache(_: &Self::Config) -> Result<()> {


### PR DESCRIPTION
Currently, the `metapac update-all` command for `pipx` calls the following command:

```bash
pipx update-all
```

which raises the following error:

```
pipx: error: argument command: invalid choice: 'update-all' (choose from install, install-all, uninject, inject, pin, unpin, upgrade, upgrade-all, upgrade-shared, uninstall, uninstall-all, reinstall, reinstall-all, list, interpreter, run, runpip, ensurepath, environment, completions)
```

Fixing this issue by calling this command instead:

```bash
pipx upgrade-all
```

Note: it's my first time with Rust, I'm not sure how to test this 😅 