### PR TITLE
feat: Add Nix backend support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added a new `nix` backend using `nix profile`, including package options for
+  `installable` and `priority`, plus backend config options for `profile`,
+  `impure`, and `accept_flake_config`.
+
 ## [0.9.4] - 2026-04-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ for additional backends are always welcome!
 | [`flatpak`](#flatpak) |
 | [`mas`](#mas)         |
 | [`mise`](#mise)       |
+| [`nix`](#nix)         |
 | [`npm`](#npm)         |
 | [`pipx`](#pipx)       |
 | [`pnpm`](#pnpm)       |
@@ -238,6 +239,13 @@ Standard usage.
 ### mise
 
 Standard usage.
+
+### nix
+
+The `nix` backend uses `nix profile` commands.
+
+Packages are matched by profile element name. If you use custom installables
+you should set `options.installable` explicitly so installs are reproducible.
 
 ### npm
 
@@ -343,6 +351,19 @@ locked = false
 # This can be faster for installing packages as it downloads pre-built binaries.
 # Default: false
 binstall = false
+
+[nix]
+# Optional profile path to operate on. If unset, nix uses the default profile.
+# Default: None
+profile = "/home/alice/.local/state/nix/profiles/profile"
+
+# Pass --impure to nix commands that evaluate installables.
+# Default: false
+impure = false
+
+# Pass --accept-flake-config to nix commands that evaluate installables.
+# Default: false
+accept_flake_config = false
 
 [vscode]
 # Since VSCode and VSCodium both operate on the same package database
@@ -510,6 +531,12 @@ mise = {
     { name = "package3", options = { version = "lts" } },
   ]
 }
+nix = {
+  packages = [
+    "hello",
+    { name = "ripgrep", options = { installable = "nixpkgs#ripgrep", priority = 4 } },
+  ]
+}
 npm = { packages = ["package1", { name = "package2" }] }
 pipx = { packages = ["package1", { name = "package2" }] }
 pnpm = { packages = ["package1", { name = "package2" }] }
@@ -550,7 +577,6 @@ of any other package managers we should be aware of.
 - [`emerge`](https://wiki.gentoo.org/wiki/Emerge): no attempt made yet
 - [`guix`](https://codeberg.org/guix/guix): no attempt made yet
 - [`nala`](https://github.com/volitank/nala): no attempt made yet
-- [`nix`](https://github.com/NixOS/nix): no attempt made yet
 - [`opkg`](https://github.com/oe-mirrors/opkg): no attempt made yet
 - [`pip`](https://pypi.org/project/pip/): we support `pipx` instead which
   only allows you to install cli programs which makes sense for a global

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -8,6 +8,7 @@ pub mod dnf;
 pub mod flatpak;
 pub mod mas;
 pub mod mise;
+pub mod nix;
 pub mod npm;
 pub mod pipx;
 pub mod pnpm;
@@ -36,6 +37,7 @@ macro_rules! apply_backends {
         (Flatpak, flatpak),
         (Mas, mas),
         (Mise, mise),
+        (Nix, nix),
         (Npm, npm),
         (Pipx, pipx),
         (Pnpm, pnpm),

--- a/src/backends/nix.rs
+++ b/src/backends/nix.rs
@@ -1,0 +1,250 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use color_eyre::Result;
+use color_eyre::eyre::eyre;
+use indoc::formatdoc;
+use serde::{Deserialize, Serialize};
+
+use crate::cmd::{run_command, run_command_for_stdout};
+use crate::prelude::*;
+
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord, derive_more::Display)]
+pub struct Nix;
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct NixConfig {
+    #[serde(default)]
+    pub profile: Option<String>,
+    #[serde(default)]
+    pub impure: bool,
+    #[serde(default)]
+    pub accept_flake_config: bool,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NixPackageOptions {
+    pub installable: Option<String>,
+    pub priority: Option<u32>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NixRepoOptions {}
+
+#[derive(Debug, Deserialize)]
+struct NixProfileList {
+    elements: BTreeMap<String, NixProfileElement>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct NixProfileElement {
+    attr_path: Option<String>,
+    original_url: Option<String>,
+    priority: Option<u32>,
+}
+
+impl Backend for Nix {
+    type Config = NixConfig;
+    type PackageOptions = NixPackageOptions;
+    type RepoOptions = NixRepoOptions;
+
+    fn invalid_package_help_text() -> String {
+        formatdoc! {"
+            A nix package may be invalid due to one of the following issues:
+                - package names must not be empty, contain whitespace, or start with '-'
+                - package names are matched against nix profile element names, so if a package
+                  keeps showing as unmanaged run `metapac unmanaged` and copy the generated name
+                - if the package source is not `nixpkgs#<name>`, set `options.installable`
+                  explicitly to the installable you want metapac to install
+        "}
+    }
+
+    fn is_valid_package_name(package: &str) -> Option<bool> {
+        let has_whitespace = package.chars().any(char::is_whitespace);
+
+        if package.trim().is_empty() || package.starts_with('-') || has_whitespace {
+            Some(false)
+        } else {
+            None
+        }
+    }
+
+    fn get_all_packages(_: &Self::Config) -> Result<BTreeSet<String>> {
+        Err(eyre!("unimplemented"))
+    }
+
+    fn get_installed_packages(
+        config: &Self::Config,
+    ) -> Result<BTreeMap<String, Self::PackageOptions>> {
+        if Self::version(config).is_err() {
+            return Ok(BTreeMap::new());
+        }
+
+        let mut args = vec![
+            "nix".to_string(),
+            "profile".to_string(),
+            "list".to_string(),
+            "--json".to_string(),
+            "--no-pretty".to_string(),
+        ];
+        append_profile_arg(&mut args, config);
+
+        let output = run_command_for_stdout(args, Perms::Same, StdErr::Show)?;
+        parse_installed_packages(&output)
+    }
+
+    fn install_packages(
+        packages: &BTreeMap<String, Self::PackageOptions>,
+        _: bool,
+        config: &Self::Config,
+    ) -> Result<()> {
+        for (name, options) in packages {
+            let mut args = vec!["nix".to_string(), "profile".to_string(), "add".to_string()];
+            append_profile_arg(&mut args, config);
+            append_eval_flags(&mut args, config);
+
+            if let Some(priority) = options.priority {
+                args.push("--priority".to_string());
+                args.push(priority.to_string());
+            }
+
+            args.push(installable_for(name, options));
+
+            run_command(args, Perms::Same)?;
+        }
+
+        Ok(())
+    }
+
+    fn uninstall_packages(
+        packages: &BTreeSet<String>,
+        _: bool,
+        config: &Self::Config,
+    ) -> Result<()> {
+        if !packages.is_empty() {
+            let mut args = vec![
+                "nix".to_string(),
+                "profile".to_string(),
+                "remove".to_string(),
+            ];
+            append_profile_arg(&mut args, config);
+            args.extend(packages.iter().cloned());
+            run_command(args, Perms::Same)?;
+        }
+
+        Ok(())
+    }
+
+    fn update_packages(packages: &BTreeSet<String>, _: bool, config: &Self::Config) -> Result<()> {
+        if !packages.is_empty() {
+            let mut args = vec![
+                "nix".to_string(),
+                "profile".to_string(),
+                "upgrade".to_string(),
+            ];
+            append_profile_arg(&mut args, config);
+            append_eval_flags(&mut args, config);
+            args.extend(packages.iter().cloned());
+            run_command(args, Perms::Same)?;
+        }
+
+        Ok(())
+    }
+
+    fn update_all_packages(_: bool, config: &Self::Config) -> Result<()> {
+        let mut args = vec![
+            "nix".to_string(),
+            "profile".to_string(),
+            "upgrade".to_string(),
+            "--all".to_string(),
+        ];
+        append_profile_arg(&mut args, config);
+        append_eval_flags(&mut args, config);
+        run_command(args, Perms::Same)
+    }
+
+    fn clean_cache(config: &Self::Config) -> Result<()> {
+        Self::version(config).map_or(Ok(()), |_| run_command(["nix", "store", "gc"], Perms::Same))
+    }
+
+    fn get_installed_repos(_: &Self::Config) -> Result<BTreeMap<String, Self::RepoOptions>> {
+        Ok(BTreeMap::new())
+    }
+
+    fn add_repos(
+        repos: &BTreeMap<String, Self::RepoOptions>,
+        _: bool,
+        _: &Self::Config,
+    ) -> Result<()> {
+        if repos.is_empty() {
+            Ok(())
+        } else {
+            Err(eyre!("unimplemented"))
+        }
+    }
+
+    fn remove_repos(repos: &BTreeSet<String>, _: bool, _: &Self::Config) -> Result<()> {
+        if repos.is_empty() {
+            Ok(())
+        } else {
+            Err(eyre!("unimplemented"))
+        }
+    }
+
+    fn version(_: &Self::Config) -> Result<String> {
+        run_command_for_stdout(["nix", "--version"], Perms::Same, StdErr::Show)
+    }
+}
+
+fn append_profile_arg(args: &mut Vec<String>, config: &NixConfig) {
+    if let Some(profile) = &config.profile {
+        args.push("--profile".to_string());
+        args.push(profile.clone());
+    }
+}
+
+fn append_eval_flags(args: &mut Vec<String>, config: &NixConfig) {
+    if config.impure {
+        args.push("--impure".to_string());
+    }
+    if config.accept_flake_config {
+        args.push("--accept-flake-config".to_string());
+    }
+}
+
+fn installable_for(name: &str, options: &NixPackageOptions) -> String {
+    options
+        .installable
+        .clone()
+        .unwrap_or_else(|| format!("nixpkgs#{name}"))
+}
+
+fn parse_installed_packages(stdout: &str) -> Result<BTreeMap<String, NixPackageOptions>> {
+    let profile_list: NixProfileList = serde_json::from_str(stdout)?;
+
+    let installed = profile_list
+        .elements
+        .into_iter()
+        .map(|(name, element)| {
+            let installable = element
+                .original_url
+                .zip(element.attr_path)
+                .map(|(original_url, attr_path)| format!("{original_url}#{attr_path}"));
+
+            let priority = element.priority.filter(|priority| *priority != 5);
+
+            (
+                name,
+                NixPackageOptions {
+                    installable,
+                    priority,
+                },
+            )
+        })
+        .collect();
+
+    Ok(installed)
+}

--- a/src/backends/nix.rs
+++ b/src/backends/nix.rs
@@ -247,7 +247,7 @@ fn parse_installed_packages(stdout: &str) -> Result<BTreeMap<String, NixPackageO
                 .filter(|priority| *priority != 5);
 
             Ok((
-                name.to_string(),
+                name.clone(),
                 NixPackageOptions {
                     installable,
                     priority,

--- a/src/backends/nix.rs
+++ b/src/backends/nix.rs
@@ -33,19 +33,6 @@ pub struct NixPackageOptions {
 #[serde(deny_unknown_fields)]
 pub struct NixRepoOptions {}
 
-#[derive(Debug, Deserialize)]
-struct NixProfileList {
-    elements: BTreeMap<String, NixProfileElement>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct NixProfileElement {
-    attr_path: Option<String>,
-    original_url: Option<String>,
-    priority: Option<u32>,
-}
-
 impl Backend for Nix {
     type Config = NixConfig;
     type PackageOptions = NixPackageOptions;
@@ -83,14 +70,13 @@ impl Backend for Nix {
             return Ok(BTreeMap::new());
         }
 
-        let mut args = vec![
-            "nix".to_string(),
-            "profile".to_string(),
-            "list".to_string(),
-            "--json".to_string(),
-            "--no-pretty".to_string(),
-        ];
-        append_profile_arg(&mut args, config);
+        let mut args = vec!["nix", "profile", "list", "--json", "--no-pretty"]
+            .into_iter()
+            .map(String::from)
+            .collect::<Vec<_>>();
+        if let Some(profile) = &config.profile {
+            args.extend(["--profile".to_string(), profile.clone()]);
+        }
 
         let output = run_command_for_stdout(args, Perms::Same, StdErr::Show)?;
         parse_installed_packages(&output)
@@ -102,8 +88,13 @@ impl Backend for Nix {
         config: &Self::Config,
     ) -> Result<()> {
         for (name, options) in packages {
-            let mut args = vec!["nix".to_string(), "profile".to_string(), "add".to_string()];
-            append_profile_arg(&mut args, config);
+            let mut args = vec!["nix", "profile", "add"]
+                .into_iter()
+                .map(String::from)
+                .collect::<Vec<_>>();
+            if let Some(profile) = &config.profile {
+                args.extend(["--profile".to_string(), profile.clone()]);
+            }
             append_eval_flags(&mut args, config);
 
             if let Some(priority) = options.priority {
@@ -111,7 +102,12 @@ impl Backend for Nix {
                 args.push(priority.to_string());
             }
 
-            args.push(installable_for(name, options));
+            args.push(
+                options
+                    .installable
+                    .clone()
+                    .unwrap_or_else(|| format!("nixpkgs#{name}")),
+            );
 
             run_command(args, Perms::Same)?;
         }
@@ -125,12 +121,13 @@ impl Backend for Nix {
         config: &Self::Config,
     ) -> Result<()> {
         if !packages.is_empty() {
-            let mut args = vec![
-                "nix".to_string(),
-                "profile".to_string(),
-                "remove".to_string(),
-            ];
-            append_profile_arg(&mut args, config);
+            let mut args = vec!["nix", "profile", "remove"]
+                .into_iter()
+                .map(String::from)
+                .collect::<Vec<_>>();
+            if let Some(profile) = &config.profile {
+                args.extend(["--profile".to_string(), profile.clone()]);
+            }
             args.extend(packages.iter().cloned());
             run_command(args, Perms::Same)?;
         }
@@ -140,12 +137,13 @@ impl Backend for Nix {
 
     fn update_packages(packages: &BTreeSet<String>, _: bool, config: &Self::Config) -> Result<()> {
         if !packages.is_empty() {
-            let mut args = vec![
-                "nix".to_string(),
-                "profile".to_string(),
-                "upgrade".to_string(),
-            ];
-            append_profile_arg(&mut args, config);
+            let mut args = vec!["nix", "profile", "upgrade"]
+                .into_iter()
+                .map(String::from)
+                .collect::<Vec<_>>();
+            if let Some(profile) = &config.profile {
+                args.extend(["--profile".to_string(), profile.clone()]);
+            }
             append_eval_flags(&mut args, config);
             args.extend(packages.iter().cloned());
             run_command(args, Perms::Same)?;
@@ -155,13 +153,13 @@ impl Backend for Nix {
     }
 
     fn update_all_packages(_: bool, config: &Self::Config) -> Result<()> {
-        let mut args = vec![
-            "nix".to_string(),
-            "profile".to_string(),
-            "upgrade".to_string(),
-            "--all".to_string(),
-        ];
-        append_profile_arg(&mut args, config);
+        let mut args = vec!["nix", "profile", "upgrade", "--all"]
+            .into_iter()
+            .map(String::from)
+            .collect::<Vec<_>>();
+        if let Some(profile) = &config.profile {
+            args.extend(["--profile".to_string(), profile.clone()]);
+        }
         append_eval_flags(&mut args, config);
         run_command(args, Perms::Same)
     }
@@ -199,13 +197,6 @@ impl Backend for Nix {
     }
 }
 
-fn append_profile_arg(args: &mut Vec<String>, config: &NixConfig) {
-    if let Some(profile) = &config.profile {
-        args.push("--profile".to_string());
-        args.push(profile.clone());
-    }
-}
-
 fn append_eval_flags(args: &mut Vec<String>, config: &NixConfig) {
     if config.impure {
         args.push("--impure".to_string());
@@ -215,36 +206,53 @@ fn append_eval_flags(args: &mut Vec<String>, config: &NixConfig) {
     }
 }
 
-fn installable_for(name: &str, options: &NixPackageOptions) -> String {
-    options
-        .installable
-        .clone()
-        .unwrap_or_else(|| format!("nixpkgs#{name}"))
-}
-
 fn parse_installed_packages(stdout: &str) -> Result<BTreeMap<String, NixPackageOptions>> {
-    let profile_list: NixProfileList = serde_json::from_str(stdout)?;
+    let profile_list: serde_json::Value = serde_json::from_str(stdout)?;
+    let elements = profile_list["elements"]
+        .as_object()
+        .ok_or(eyre!("expected `elements` to be an object"))?;
 
-    let installed = profile_list
-        .elements
-        .into_iter()
+    elements
+        .iter()
         .map(|(name, element)| {
-            let installable = element
-                .original_url
-                .zip(element.attr_path)
+            let element = element
+                .as_object()
+                .ok_or(eyre!("expected profile element to be an object"))?;
+
+            let original_url = element
+                .get("originalUrl")
+                .map(|x| {
+                    x.as_str()
+                        .ok_or(eyre!("expected `originalUrl` to be a string"))
+                })
+                .transpose()?;
+            let attr_path = element
+                .get("attrPath")
+                .map(|x| {
+                    x.as_str()
+                        .ok_or(eyre!("expected `attrPath` to be a string"))
+                })
+                .transpose()?;
+            let installable = original_url
+                .zip(attr_path)
                 .map(|(original_url, attr_path)| format!("{original_url}#{attr_path}"));
 
-            let priority = element.priority.filter(|priority| *priority != 5);
+            let priority = element
+                .get("priority")
+                .map(|x| {
+                    let priority = x.as_u64().ok_or(eyre!("expected `priority` to be a u64"))?;
+                    u32::try_from(priority).map_err(|_| eyre!("priority overflows u32"))
+                })
+                .transpose()?
+                .filter(|priority| *priority != 5);
 
-            (
-                name,
+            Ok((
+                name.to_string(),
                 NixPackageOptions {
                     installable,
                     priority,
                 },
-            )
+            ))
         })
-        .collect();
-
-    Ok(installed)
+        .collect()
 }

--- a/src/backends/nix.rs
+++ b/src/backends/nix.rs
@@ -70,13 +70,11 @@ impl Backend for Nix {
             return Ok(BTreeMap::new());
         }
 
-        let mut args = vec!["nix", "profile", "list", "--json", "--no-pretty"]
+        let args = ["nix", "profile", "list", "--json", "--no-pretty"]
             .into_iter()
             .map(String::from)
+            .chain(profile_args(config))
             .collect::<Vec<_>>();
-        if let Some(profile) = &config.profile {
-            args.extend(["--profile".to_string(), profile.clone()]);
-        }
 
         let output = run_command_for_stdout(args, Perms::Same, StdErr::Show)?;
         parse_installed_packages(&output)
@@ -88,26 +86,24 @@ impl Backend for Nix {
         config: &Self::Config,
     ) -> Result<()> {
         for (name, options) in packages {
-            let mut args = vec!["nix", "profile", "add"]
+            let args = ["nix", "profile", "add"]
                 .into_iter()
                 .map(String::from)
+                .chain(profile_args(config))
+                .chain(eval_flag_args(config))
+                .chain(
+                    options
+                        .priority
+                        .into_iter()
+                        .flat_map(|priority| ["--priority".to_string(), priority.to_string()]),
+                )
+                .chain(std::iter::once(
+                    options
+                        .installable
+                        .clone()
+                        .unwrap_or_else(|| format!("nixpkgs#{name}")),
+                ))
                 .collect::<Vec<_>>();
-            if let Some(profile) = &config.profile {
-                args.extend(["--profile".to_string(), profile.clone()]);
-            }
-            append_eval_flags(&mut args, config);
-
-            if let Some(priority) = options.priority {
-                args.push("--priority".to_string());
-                args.push(priority.to_string());
-            }
-
-            args.push(
-                options
-                    .installable
-                    .clone()
-                    .unwrap_or_else(|| format!("nixpkgs#{name}")),
-            );
 
             run_command(args, Perms::Same)?;
         }
@@ -121,14 +117,12 @@ impl Backend for Nix {
         config: &Self::Config,
     ) -> Result<()> {
         if !packages.is_empty() {
-            let mut args = vec!["nix", "profile", "remove"]
+            let args = ["nix", "profile", "remove"]
                 .into_iter()
                 .map(String::from)
+                .chain(profile_args(config))
+                .chain(packages.iter().cloned())
                 .collect::<Vec<_>>();
-            if let Some(profile) = &config.profile {
-                args.extend(["--profile".to_string(), profile.clone()]);
-            }
-            args.extend(packages.iter().cloned());
             run_command(args, Perms::Same)?;
         }
 
@@ -137,15 +131,13 @@ impl Backend for Nix {
 
     fn update_packages(packages: &BTreeSet<String>, _: bool, config: &Self::Config) -> Result<()> {
         if !packages.is_empty() {
-            let mut args = vec!["nix", "profile", "upgrade"]
+            let args = ["nix", "profile", "upgrade"]
                 .into_iter()
                 .map(String::from)
+                .chain(profile_args(config))
+                .chain(eval_flag_args(config))
+                .chain(packages.iter().cloned())
                 .collect::<Vec<_>>();
-            if let Some(profile) = &config.profile {
-                args.extend(["--profile".to_string(), profile.clone()]);
-            }
-            append_eval_flags(&mut args, config);
-            args.extend(packages.iter().cloned());
             run_command(args, Perms::Same)?;
         }
 
@@ -153,14 +145,12 @@ impl Backend for Nix {
     }
 
     fn update_all_packages(_: bool, config: &Self::Config) -> Result<()> {
-        let mut args = vec!["nix", "profile", "upgrade", "--all"]
+        let args = ["nix", "profile", "upgrade", "--all"]
             .into_iter()
             .map(String::from)
+            .chain(profile_args(config))
+            .chain(eval_flag_args(config))
             .collect::<Vec<_>>();
-        if let Some(profile) = &config.profile {
-            args.extend(["--profile".to_string(), profile.clone()]);
-        }
-        append_eval_flags(&mut args, config);
         run_command(args, Perms::Same)
     }
 
@@ -197,13 +187,24 @@ impl Backend for Nix {
     }
 }
 
-fn append_eval_flags(args: &mut Vec<String>, config: &NixConfig) {
-    if config.impure {
-        args.push("--impure".to_string());
-    }
-    if config.accept_flake_config {
-        args.push("--accept-flake-config".to_string());
-    }
+fn profile_args(config: &NixConfig) -> impl Iterator<Item = String> {
+    config
+        .profile
+        .iter()
+        .cloned()
+        .flat_map(|profile| ["--profile".to_string(), profile])
+}
+
+fn eval_flag_args(config: &NixConfig) -> impl Iterator<Item = String> {
+    config
+        .impure
+        .then_some("--impure".to_string())
+        .into_iter()
+        .chain(
+            config
+                .accept_flake_config
+                .then_some("--accept-flake-config".to_string()),
+        )
 }
 
 fn parse_installed_packages(stdout: &str) -> Result<BTreeMap<String, NixPackageOptions>> {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -13,6 +13,7 @@ pub use crate::backends::dnf::{Dnf, DnfConfig, DnfPackageOptions};
 pub use crate::backends::flatpak::{Flatpak, FlatpakConfig, FlatpakPackageOptions};
 pub use crate::backends::mas::{Mas, MasConfig, MasPackageOptions};
 pub use crate::backends::mise::{Mise, MiseConfig, MisePackageOptions};
+pub use crate::backends::nix::{Nix, NixConfig, NixPackageOptions};
 pub use crate::backends::npm::{Npm, NpmPackageOptions};
 pub use crate::backends::pipx::{Pipx, PipxPackageOptions};
 pub use crate::backends::pnpm::{Pnpm, PnpmPackageOptions};


### PR DESCRIPTION
Related to #219 

I took a first pass at Nix support in Metapac, using `nix profile` as the backend.

What’s in:
  - basic package lifecycle works: list, install (sync), remove (clean), update (update / update-all)
  - `clean-cache` for nix runs `nix store gc`
  - Nix packages in groups can use:
      - name (used as the stable package id in metapac)
      - optional options.installable (if missing, it falls back to nixpkgs#<name>)
      - optional options.priority
  - backend config got a few practical knobs:
      - profile
      - impure
      - accept_flake_config

What’s not in (yet):

  - nix “repo-like” things (registries/channels/etc).

Why these choices:

  - nix profile is the modern CLI and works across distros, not just NixOS.
  - Using name as identity keeps metapac diffs predictable for sync/clean/unmanaged.
  - installable stays optional so common cases are still easy, but custom flakes/sources are supported.

Validation:

  - fmt/test/clippy all pass
  - I also ran manual end-to-end checks with cargo run -- ... + real nix commands:
      - install worked
      - upgrade worked
      - removal worked
      - unmanaged output looked correct

Happy to incorporate any feedback !