### PR TITLE
Add a `metapac refresh` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added a new `nix` backend using `nix profile`, including package options for
   `installable` and `priority`, plus backend config options for `profile`,
-  `impure`, and `accept_flake_config`.
+  `impure`, and `accept_flake_config` (requested in #219, fixed in #220),
+  thanks @maax3v3!
+
+- Added a new `metapac refresh` subcommand to allow the updating of
+  backends' local package metadata (e.g. `apt-get update` for `apt`, `brew
+  update` for `brew`, `dnf makecache` for `dnf`) (requested in #230, fixed
+  in #231), thanks @lrntgr!
 
 ## [0.9.4] - 2026-04-05
 
@@ -43,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a panic when parsing `flatpak` remotes and removed `sudo` from all
   `flatpak` commands as `flatpak` does its own privilege escalation
   (reported in #207, fixed in #208)
- 
+
 ## [0.9.0] - 2026-01-25
 
 ‼️ This is a extremely breaking release. All users will need to fix their

--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ examples.
 Repo/package hooks are run before/after installing all repos/packages, not
 between each repo/package.
 
+### Refreshing backend package metadata
+
+Run `metapac refresh` to refresh local package metadata for the enabled
+backends, such as running `apt-get update`, `brew update`, `dnf makecache`,
+or similar commands depending on the backend. Like `metapac clean-cache`,
+you can pass `--backends` to choose specific backends or `--backends all` to
+operate on all backends.
+
 ### Enable more logs for debugging
 
 You can enable additional log levels by setting the `RUST_LOG` environment

--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ or similar commands depending on the backend. Like `metapac clean-cache`,
 you can pass `--backends` to choose specific backends or `--backends all` to
 operate on all backends.
 
+You can also pass `--refresh` to `metapac sync`, `metapac update`, or
+`metapac update-all` to refresh package metadata before installing or
+updating packages.
+
 ### Enable more logs for debugging
 
 You can enable additional log levels by setting the `RUST_LOG` environment

--- a/README.md
+++ b/README.md
@@ -131,15 +131,10 @@ between each repo/package.
 
 ### Refreshing backend package metadata
 
-Run `metapac refresh` to refresh local package metadata for the enabled
-backends, such as running `apt-get update`, `brew update`, `dnf makecache`,
-or similar commands depending on the backend. Like `metapac clean-cache`,
-you can pass `--backends` to choose specific backends or `--backends all` to
-operate on all backends.
-
-You can also pass `--refresh` to `metapac sync`, `metapac update`, or
-`metapac update-all` to refresh package metadata before installing or
-updating packages.
+Run `metapac refresh` to update local package metadata for all enabled
+backends (e.g. `apt-get update` for `apt`, `brew update` for `brew`, `dnf
+makecache` for `dnf`). Use `--backends` to target specific backends, or
+`--backends all` to include every backend.
 
 ### Enable more logs for debugging
 

--- a/src/backends/all.rs
+++ b/src/backends/all.rs
@@ -35,6 +35,11 @@ macro_rules! any_backend {
                     $( AnyBackend::$upper_backend => $upper_backend::clean_cache(&config.$lower_backend), )*
                 }
             }
+            pub fn refresh(&self, config: &BackendConfigs) -> Result<()> {
+                match self {
+                    $( AnyBackend::$upper_backend => $upper_backend::refresh(&config.$lower_backend), )*
+                }
+            }
             pub fn update(&self, packages: &BTreeSet<String>, no_confirm: bool, config: &BackendConfigs) -> Result<()> {
                 match self {
                     $( AnyBackend::$upper_backend => $upper_backend::update_packages(packages, no_confirm, &config.$lower_backend), )*

--- a/src/backends/apt.rs
+++ b/src/backends/apt.rs
@@ -139,6 +139,10 @@ impl Backend for Apt {
         })
     }
 
+    fn refresh(_: &Self::Config) -> Result<()> {
+        run_command(["apt-get", "update"], Perms::Sudo)
+    }
+
     fn get_installed_repos(_: &Self::Config) -> Result<BTreeMap<String, Self::RepoOptions>> {
         Ok(BTreeMap::new())
     }

--- a/src/backends/arch.rs
+++ b/src/backends/arch.rs
@@ -255,6 +255,13 @@ impl Backend for Arch {
         })
     }
 
+    fn refresh(config: &Self::Config) -> Result<()> {
+        run_command(
+            [config.package_manager.as_command(), "--sync", "--refresh"],
+            config.package_manager.change_perms(),
+        )
+    }
+
     fn get_installed_repos(_: &Self::Config) -> Result<BTreeMap<String, Self::RepoOptions>> {
         Ok(BTreeMap::new())
     }

--- a/src/backends/brew.rs
+++ b/src/backends/brew.rs
@@ -72,10 +72,7 @@ impl Backend for Brew {
         _: &Self::Config,
     ) -> Result<()> {
         for package in packages.keys() {
-            run_command(
-                ["brew", "install", package.as_str()].into_iter(),
-                Perms::Same,
-            )?;
+            run_command(["brew", "install", package.as_str()], Perms::Same)?;
         }
 
         Ok(())
@@ -115,6 +112,10 @@ impl Backend for Brew {
         Self::version(config).map_or(Ok(()), |_| {
             run_command(["brew", "cleanup", "--prune-prefix"], Perms::Same)
         })
+    }
+
+    fn refresh(_: &Self::Config) -> Result<()> {
+        run_command(["brew", "update"], Perms::Same)
     }
 
     fn get_installed_repos(_: &Self::Config) -> Result<BTreeMap<String, Self::RepoOptions>> {

--- a/src/backends/dnf.rs
+++ b/src/backends/dnf.rs
@@ -139,6 +139,10 @@ impl Backend for Dnf {
         })
     }
 
+    fn refresh(_: &Self::Config) -> Result<()> {
+        run_command(["dnf", "makecache"], Perms::Sudo)
+    }
+
     fn get_installed_repos(_: &Self::Config) -> Result<BTreeMap<String, Self::RepoOptions>> {
         let repos = run_command_for_stdout(["dnf", "copr", "list"], Perms::Sudo, StdErr::Show)?;
 

--- a/src/backends/flatpak.rs
+++ b/src/backends/flatpak.rs
@@ -203,6 +203,10 @@ impl Backend for Flatpak {
         })
     }
 
+    fn refresh(_: &Self::Config) -> Result<()> {
+        run_command(["flatpak", "update", "--appstream"], Perms::Same)
+    }
+
     fn get_installed_repos(_: &Self::Config) -> Result<BTreeMap<String, Self::RepoOptions>> {
         let repos = run_command_for_stdout(
             ["flatpak", "remotes", "--columns", "options,name,url"],

--- a/src/backends/mise.rs
+++ b/src/backends/mise.rs
@@ -149,6 +149,10 @@ impl Backend for Mise {
         Ok(())
     }
 
+    fn refresh(_: &Self::Config) -> Result<()> {
+        run_command(["mise", "plugins", "update"], Perms::Same)
+    }
+
     fn get_installed_repos(_: &Self::Config) -> Result<BTreeMap<String, Self::RepoOptions>> {
         Ok(BTreeMap::new())
     }

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -137,8 +137,8 @@ pub trait Backend {
 
     /// Attempts to refresh the backend's local package metadata.
     ///
-    /// Backends that do not have a separate metadata/index refresh operation should use the
-    /// default no-op implementation.
+    /// Backends that do not have a local package metadata refresh operation should have a no-op
+    /// implementation.
     fn refresh(_config: &Self::Config) -> Result<()> {
         Ok(())
     }

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -135,6 +135,14 @@ pub trait Backend {
     /// Attempts to clean all cache.
     fn clean_cache(config: &Self::Config) -> Result<()>;
 
+    /// Attempts to refresh the backend's local package metadata.
+    ///
+    /// Backends that do not have a separate metadata/index refresh operation should use the
+    /// default no-op implementation.
+    fn refresh(_config: &Self::Config) -> Result<()> {
+        Ok(())
+    }
+
     /// Attempts to return the currently active repos.
     fn get_installed_repos(config: &Self::Config) -> Result<BTreeMap<String, Self::RepoOptions>>;
 

--- a/src/backends/scoop.rs
+++ b/src/backends/scoop.rs
@@ -125,6 +125,10 @@ impl Backend for Scoop {
         run_command(["scoop.cmd", "cleanup", "--all", "--cache"], Perms::Same)
     }
 
+    fn refresh(_: &Self::Config) -> Result<()> {
+        run_command(["scoop.cmd", "update"], Perms::Same)
+    }
+
     fn get_installed_repos(_: &Self::Config) -> Result<BTreeMap<String, Self::RepoOptions>> {
         Ok(BTreeMap::new())
     }

--- a/src/backends/winget.rs
+++ b/src/backends/winget.rs
@@ -143,6 +143,10 @@ impl Backend for WinGet {
         Ok(())
     }
 
+    fn refresh(_: &Self::Config) -> Result<()> {
+        run_command(["winget", "source", "update"], Perms::Same)
+    }
+
     fn get_installed_repos(_: &Self::Config) -> Result<BTreeMap<String, Self::RepoOptions>> {
         Ok(BTreeMap::new())
     }

--- a/src/backends/xbps.rs
+++ b/src/backends/xbps.rs
@@ -148,6 +148,10 @@ impl Backend for Xbps {
         })
     }
 
+    fn refresh(_: &Self::Config) -> Result<()> {
+        run_command(["xbps-install", "--sync"], Perms::Sudo)
+    }
+
     fn get_installed_repos(_: &Self::Config) -> Result<BTreeMap<String, Self::RepoOptions>> {
         Ok(BTreeMap::new())
     }

--- a/src/backends/zypper.rs
+++ b/src/backends/zypper.rs
@@ -143,6 +143,10 @@ impl Backend for Zypper {
         Self::version(config).map_or(Ok(()), |_| run_command(["zypper", "clean"], Perms::Sudo))
     }
 
+    fn refresh(_: &Self::Config) -> Result<()> {
+        run_command(["zypper", "refresh"], Perms::Sudo)
+    }
+
     fn get_installed_repos(_: &Self::Config) -> Result<BTreeMap<String, Self::RepoOptions>> {
         Ok(BTreeMap::new())
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,6 +32,7 @@ pub enum MainSubcommand {
     Unmanaged(UnmanagedCommand),
     Backends(BackendsCommand),
     CleanCache(CleanCacheCommand),
+    Refresh(RefreshCommand),
     Completions(CompletionsCommand),
 }
 
@@ -97,6 +98,20 @@ pub struct BackendsCommand {}
 #[derive(Args)]
 /// clean the caches for the given backends
 pub struct CleanCacheCommand {
+    #[arg(long)]
+    /// the backends to operate on
+    ///
+    /// - if no backends are passed then the `enabled_backends` config is used
+    ///
+    /// - if "all" is passed by itself then all backends are used
+    ///
+    /// - otherwise the list will be parsed as a list of backends to be used
+    pub backends: Vec<String>,
+}
+
+#[derive(Args)]
+/// refresh package metadata for the given backends
+pub struct RefreshCommand {
     #[arg(long)]
     /// the backends to operate on
     ///

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,6 +46,9 @@ pub struct UpdateCommand {
     /// the package names
     pub packages: Vec<String>,
     #[arg(long)]
+    /// refresh package metadata before updating packages
+    pub refresh: bool,
+    #[arg(long)]
     /// do not ask for any confirmation
     pub no_confirm: bool,
 }
@@ -63,6 +66,9 @@ pub struct UpdateAllCommand {
     /// - otherwise the list will be parsed as a list of backends to be used
     pub backends: Vec<String>,
     #[arg(long)]
+    /// refresh package metadata before updating packages
+    pub refresh: bool,
+    #[arg(long)]
     /// do not ask for any confirmation
     pub no_confirm: bool,
 }
@@ -78,6 +84,9 @@ pub struct CleanCommand {
 #[derive(Args)]
 /// install missing packages from groups
 pub struct SyncCommand {
+    #[arg(long)]
+    /// refresh package metadata before installing packages
+    pub refresh: bool,
     #[arg(long)]
     /// do not ask for any confirmation
     pub no_confirm: bool,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,9 +46,6 @@ pub struct UpdateCommand {
     /// the package names
     pub packages: Vec<String>,
     #[arg(long)]
-    /// refresh package metadata before updating packages
-    pub refresh: bool,
-    #[arg(long)]
     /// do not ask for any confirmation
     pub no_confirm: bool,
 }
@@ -66,9 +63,6 @@ pub struct UpdateAllCommand {
     /// - otherwise the list will be parsed as a list of backends to be used
     pub backends: Vec<String>,
     #[arg(long)]
-    /// refresh package metadata before updating packages
-    pub refresh: bool,
-    #[arg(long)]
     /// do not ask for any confirmation
     pub no_confirm: bool,
 }
@@ -84,9 +78,6 @@ pub struct CleanCommand {
 #[derive(Args)]
 /// install missing packages from groups
 pub struct SyncCommand {
-    #[arg(long)]
-    /// refresh package metadata before installing packages
-    pub refresh: bool,
     #[arg(long)]
     /// do not ask for any confirmation
     pub no_confirm: bool,
@@ -119,7 +110,7 @@ pub struct CleanCacheCommand {
 }
 
 #[derive(Args)]
-/// refresh package metadata for the given backends
+/// refresh local package metadata for the given backends
 pub struct RefreshCommand {
     #[arg(long)]
     /// the backends to operate on

--- a/src/core.rs
+++ b/src/core.rs
@@ -45,6 +45,7 @@ impl Command {
             MainSubcommand::Unmanaged(unmanaged) => unmanaged.run(&hostname, &group_dir, &config),
             MainSubcommand::Backends(backends) => backends.run(&config),
             MainSubcommand::CleanCache(clean_cache) => clean_cache.run(&hostname, &config),
+            MainSubcommand::Refresh(refresh) => refresh.run(&hostname, &config),
             MainSubcommand::Completions(completions) => completions.run(),
         }
     }
@@ -232,6 +233,21 @@ impl CleanCacheCommand {
             log::info!("cleaning cache for {backend} backend");
 
             backend.clean_cache(config.backend_configs())?;
+        }
+
+        Ok(())
+    }
+}
+
+impl RefreshCommand {
+    fn run(&self, hostname: &str, config: &Config) -> Result<()> {
+        let enabled_backends = &config.enabled_backends(hostname);
+        let backends = parse_backends(&self.backends, enabled_backends)?;
+
+        for backend in backends {
+            log::info!("refreshing package metadata for {backend} backend");
+
+            backend.refresh(config.backend_configs())?;
         }
 
         Ok(())

--- a/src/core.rs
+++ b/src/core.rs
@@ -55,6 +55,10 @@ impl UpdateCommand {
     fn run(self, config: &Config) -> Result<()> {
         let packages = package_vec_to_btreeset(self.packages);
 
+        if self.refresh {
+            refresh_backend(self.backend, config.backend_configs())?;
+        }
+
         self.backend
             .update(&packages, self.no_confirm, config.backend_configs())
     }
@@ -66,6 +70,10 @@ impl UpdateAllCommand {
         let backends = parse_backends(&self.backends, enabled_backends)?;
 
         for backend in backends {
+            if self.refresh {
+                refresh_backend(backend, config.backend_configs())?;
+            }
+
             log::info!("updating all packages for {backend} backend");
 
             backend.update_all(self.no_confirm, config.backend_configs())?;
@@ -123,6 +131,11 @@ impl CleanCommand {
 impl SyncCommand {
     fn run(self, hostname: &str, group_dir: &Path, config: &Config) -> Result<()> {
         let enabled_backends = config.enabled_backends(hostname);
+
+        if self.refresh {
+            refresh_backends(&enabled_backends, config.backend_configs())?;
+        }
+
         let required = required(hostname, group_dir, config)?;
         let missing = missing(&required, &enabled_backends, config.backend_configs())?;
 
@@ -244,13 +257,7 @@ impl RefreshCommand {
         let enabled_backends = &config.enabled_backends(hostname);
         let backends = parse_backends(&self.backends, enabled_backends)?;
 
-        for backend in backends {
-            log::info!("refreshing package metadata for {backend} backend");
-
-            backend.refresh(config.backend_configs())?;
-        }
-
-        Ok(())
+        refresh_backends(&backends, config.backend_configs())
     }
 }
 
@@ -388,6 +395,23 @@ fn missing(
 
     Ok(missing)
 }
+fn refresh_backend(backend: AnyBackend, backend_configs: &BackendConfigs) -> Result<()> {
+    log::info!("refreshing package metadata for {backend} backend");
+
+    backend.refresh(backend_configs)
+}
+
+fn refresh_backends(
+    backends: &BTreeSet<AnyBackend>,
+    backend_configs: &BackendConfigs,
+) -> Result<()> {
+    for backend in backends {
+        refresh_backend(*backend, backend_configs)?;
+    }
+
+    Ok(())
+}
+
 fn package_vec_to_btreeset(vec: Vec<String>) -> BTreeSet<String> {
     let mut packages = BTreeSet::new();
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -55,10 +55,6 @@ impl UpdateCommand {
     fn run(self, config: &Config) -> Result<()> {
         let packages = package_vec_to_btreeset(self.packages);
 
-        if self.refresh {
-            refresh_backend(self.backend, config.backend_configs())?;
-        }
-
         self.backend
             .update(&packages, self.no_confirm, config.backend_configs())
     }
@@ -70,10 +66,6 @@ impl UpdateAllCommand {
         let backends = parse_backends(&self.backends, enabled_backends)?;
 
         for backend in backends {
-            if self.refresh {
-                refresh_backend(backend, config.backend_configs())?;
-            }
-
             log::info!("updating all packages for {backend} backend");
 
             backend.update_all(self.no_confirm, config.backend_configs())?;
@@ -131,11 +123,6 @@ impl CleanCommand {
 impl SyncCommand {
     fn run(self, hostname: &str, group_dir: &Path, config: &Config) -> Result<()> {
         let enabled_backends = config.enabled_backends(hostname);
-
-        if self.refresh {
-            refresh_backends(&enabled_backends, config.backend_configs())?;
-        }
-
         let required = required(hostname, group_dir, config)?;
         let missing = missing(&required, &enabled_backends, config.backend_configs())?;
 
@@ -257,7 +244,13 @@ impl RefreshCommand {
         let enabled_backends = &config.enabled_backends(hostname);
         let backends = parse_backends(&self.backends, enabled_backends)?;
 
-        refresh_backends(&backends, config.backend_configs())
+        for backend in backends {
+            log::info!("refreshing {backend} backend");
+
+            backend.refresh(config.backend_configs())?;
+        }
+
+        Ok(())
     }
 }
 
@@ -395,23 +388,6 @@ fn missing(
 
     Ok(missing)
 }
-fn refresh_backend(backend: AnyBackend, backend_configs: &BackendConfigs) -> Result<()> {
-    log::info!("refreshing package metadata for {backend} backend");
-
-    backend.refresh(backend_configs)
-}
-
-fn refresh_backends(
-    backends: &BTreeSet<AnyBackend>,
-    backend_configs: &BackendConfigs,
-) -> Result<()> {
-    for backend in backends {
-        refresh_backend(*backend, backend_configs)?;
-    }
-
-    Ok(())
-}
-
 fn package_vec_to_btreeset(vec: Vec<String>) -> BTreeSet<String> {
     let mut packages = BTreeSet::new();
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -27,7 +27,7 @@ pub use crate::backends::yarn::{Yarn, YarnPackageOptions};
 pub use crate::backends::zypper::{Zypper, ZypperPackageOptions};
 pub use crate::cli::{
     BackendsCommand, CleanCacheCommand, CleanCommand, Command, CompletionsCommand, MainSubcommand,
-    SyncCommand, UnmanagedCommand, UpdateAllCommand, UpdateCommand,
+    RefreshCommand, SyncCommand, UnmanagedCommand, UpdateAllCommand, UpdateCommand,
 };
 pub use crate::cmd::{Perms, StdErr};
 pub use crate::completions::AnyShell;

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,6 +1,30 @@
 use assert_cmd::cargo::cargo_bin_cmd;
 use markdown::{ParseOptions, mdast::Node};
 
+fn assert_help_contains(args: &[&str], needle: &str) {
+    let output = cargo_bin_cmd!().args(args).output().unwrap();
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(needle),
+        "{stdout:?} did not contain {needle:?}"
+    );
+}
+
+#[test]
+fn refresh_help() {
+    assert_help_contains(&["refresh", "--help"], "refresh package metadata");
+}
+
+#[test]
+fn sync_update_and_update_all_have_refresh_flag() {
+    assert_help_contains(&["sync", "--help"], "--refresh");
+    assert_help_contains(&["update", "--help"], "--refresh");
+    assert_help_contains(&["update-all", "--help"], "--refresh");
+}
+
 #[test]
 fn unmanaged() {
     let readme =

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,30 +1,6 @@
 use assert_cmd::cargo::cargo_bin_cmd;
 use markdown::{ParseOptions, mdast::Node};
 
-fn assert_help_contains(args: &[&str], needle: &str) {
-    let output = cargo_bin_cmd!().args(args).output().unwrap();
-
-    assert!(output.status.success());
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        stdout.contains(needle),
-        "{stdout:?} did not contain {needle:?}"
-    );
-}
-
-#[test]
-fn refresh_help() {
-    assert_help_contains(&["refresh", "--help"], "refresh package metadata");
-}
-
-#[test]
-fn sync_update_and_update_all_have_refresh_flag() {
-    assert_help_contains(&["sync", "--help"], "--refresh");
-    assert_help_contains(&["update", "--help"], "--refresh");
-    assert_help_contains(&["update-all", "--help"], "--refresh");
-}
-
 #[test]
 fn unmanaged() {
     let readme =


### PR DESCRIPTION
This PR is an attempt, or proposal, of handling the https://github.com/ripytide/metapac/issues/230 issue.

It adds a `metapac refresh` command to refresh (or update) the package manager database.  
It accepts the `--backends` option to select the backends to refresh.

It also adds a `--refresh` option to the `metapac {sync,update,update-all}` existing commands, automatically refreshing the backend before synchronizing or updating packages.