### PR TITLE
fix: clean packages before repos

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -85,7 +85,7 @@ impl CleanCommand {
         if !unmanaged.is_empty() {
             print!(
                 "{}",
-                &unmanaged.clone().to_complex().to_raw().to_string_pretty()?
+                unmanaged.clone().to_complex().to_raw().to_string_pretty()?
             );
 
             if self.no_confirm {
@@ -105,8 +105,8 @@ impl CleanCommand {
             ($(($upper_backend:ident, $lower_backend:ident)),*) => {
                 $(
                     if enabled_backends.contains(&AnyBackend::$upper_backend) {
-                        $upper_backend::remove_repos(&unmanaged.$lower_backend.repos.keys().cloned().collect(), self.no_confirm, &config.backend_configs().$lower_backend)?;
                         $upper_backend::uninstall_packages(&unmanaged.$lower_backend.packages.keys().cloned().collect(), self.no_confirm, &config.backend_configs().$lower_backend)?;
+                        $upper_backend::remove_repos(&unmanaged.$lower_backend.repos.keys().cloned().collect(), self.no_confirm, &config.backend_configs().$lower_backend)?;
                     }
                 )*
             };
@@ -128,7 +128,7 @@ impl SyncCommand {
         }
 
         if !missing.is_empty() {
-            print!("{}", &missing.clone().to_raw().to_string_pretty()?);
+            print!("{}", missing.clone().to_raw().to_string_pretty()?);
         }
 
         if self.no_confirm {
@@ -196,7 +196,7 @@ impl UnmanagedCommand {
         if unmanaged.is_empty() {
             log::info!("no unmanaged packages");
         } else {
-            print!("{}", &unmanaged.to_complex().to_raw().to_string_pretty()?);
+            print!("{}", unmanaged.to_complex().to_raw().to_string_pretty()?);
         }
 
         Ok(())


### PR DESCRIPTION
# metapac `clean` ordering fix — Description & Test Log

## Problem

In `src/core.rs`, the `CleanCommand` macro removes repos **before** packages for every backend:

```rust
$upper_backend::remove_repos(...)?;
$upper_backend::uninstall_packages(...)?;
```

This ordering is incorrect for any backend where a repo/source must remain available until its packages are removed.

### Existing backends affected

- **`dnf`**: `metapac` already supports repos via `dnf copr`. If a Copr repo is removed before packages from that Copr, `dnf` can be left with dangling package references or fail to resolve dependencies during the clean.
- **`flatpak`**: `metapac` already supports remotes. Removing a remote before uninstalling apps from it could cause `flatpak` to fail to locate the app metadata needed to perform the uninstall.
- **`apt`**: While apt repos are not yet managed by metapac, the same principle applies to any future backend that supports PPAs or other repo sources.

### Concrete failure spotted during Homebrew tap work

I noticed this while working on adding Homebrew tap support. When a brew tap is later removed from the group file, `metapac clean` tries to `brew untap <tap>` before uninstalling the packages from that tap, and Homebrew refuses:

```text
Error: Refusing to untap ublue-os/tap because it contains the following installed casks:
ublue-os/tap/aurora-wallpapers
```

## Fix

Swap the two lines in `CleanCommand` so packages are uninstalled **before** repos are removed:

```rust
$upper_backend::uninstall_packages(...)?;
$upper_backend::remove_repos(...)?;
```

This is a minimal, backend-agnostic ordering fix.

## Additional CI fixes

`cargo clippy --all-targets -- -D warnings` failed on pre-existing redundant borrows in `print!` arguments in the same file. These were fixed to allow CI to pass:

```rust
print!("{}", &unmanaged.clone().to_complex().to_raw().to_string_pretty()?);
```

became:

```rust
print!("{}", unmanaged.clone().to_complex().to_raw().to_string_pretty()?);
```

Two other identical patterns in the same file were also fixed.

## Test Log

Tested with local checkout: `/home/xariann/Projects/metapac`

### 1. `cargo check`

```text
$ cargo check
    Checking metapac v0.10.0 (/home/xariann/Projects/metapac)
    Finished `dev` profile [unoptimized + debuginfo] in 0.43s
```

### 2. `cargo clippy --all-targets -- -D warnings`

```text
$ cargo clippy --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] in 5.33s
```

### 3. Normal `clean` operation still works

With `enabled_backends = ["zypper", "cargo", "brew", "flatpak"]` and existing group files, `clean` reports nothing to remove and exits cleanly:

```text
$ cargo run -- clean --no-confirm
(no output; nothing to clean)
```

### 4. Failure reproduced with Homebrew tap support (local WIP)

While testing Homebrew tap support locally, I created a temporary group file:

```toml
brew = {
  repos = ["ublue-os/tap"],
  packages = ["aurora-wallpapers"]
}
```

After syncing, the group file was removed and `clean` was run. With the fix applied, the package was uninstalled first and the tap was successfully removed. Without the fix, `clean` fails because the tap still contains installed casks.

This homebrew tap support is not part of this PR; only the ordering fix is included here.
