### PR TITLE
feat: add Homebrew tap tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,13 @@ arch = {
     },
   ]
 }
-brew = { packages = ["package1", { name = "package2" }] }
+brew = {
+  repos = [
+    "homebrew/cask-fonts",
+    { name = "opencode-ai/tap" },
+  ],
+  packages = ["package1", { name = "package2" }]
+}
 bun = { packages = ["package1", { name = "package2" }] }
 cargo = {
   packages = [

--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ arch = {
 brew = {
   repos = [
     "homebrew/cask-fonts",
-    { name = "opencode-ai/tap" },
+    "ublue-os/tap",
   ],
   packages = ["package1", { name = "package2" }]
 }

--- a/src/backends/brew.rs
+++ b/src/backends/brew.rs
@@ -118,8 +118,17 @@ impl Backend for Brew {
         run_command(["brew", "update"], Perms::Same)
     }
 
-    fn get_installed_repos(_: &Self::Config) -> Result<BTreeMap<String, Self::RepoOptions>> {
-        Ok(BTreeMap::new())
+    fn get_installed_repos(config: &Self::Config) -> Result<BTreeMap<String, Self::RepoOptions>> {
+        if Self::version(config).is_err() {
+            return Ok(BTreeMap::new());
+        }
+
+        let taps = run_command_for_stdout(["brew", "tap"], Perms::Same, StdErr::Show)?;
+
+        Ok(taps
+            .lines()
+            .map(|x| (x.to_string(), Self::RepoOptions {}))
+            .collect())
     }
 
     fn add_repos(
@@ -127,19 +136,21 @@ impl Backend for Brew {
         _: bool,
         _: &Self::Config,
     ) -> Result<()> {
-        if repos.is_empty() {
-            Ok(())
-        } else {
-            Err(eyre!("unimplemented"))
+        for repo in repos.keys() {
+            run_command(["brew", "tap", repo.as_str()], Perms::Same)?;
+            run_command(["brew", "trust", "--tap", repo.as_str()], Perms::Same)?;
         }
+
+        Ok(())
     }
 
     fn remove_repos(repos: &BTreeSet<String>, _: bool, _: &Self::Config) -> Result<()> {
-        if repos.is_empty() {
-            Ok(())
-        } else {
-            Err(eyre!("unimplemented"))
+        for repo in repos {
+            run_command(["brew", "untap", repo.as_str()], Perms::Same)?;
+            run_command(["brew", "untrust", "--tap", repo.as_str()], Perms::Same)?;
         }
+
+        Ok(())
     }
 
     fn version(_: &Self::Config) -> Result<String> {


### PR DESCRIPTION
This PR adds declarative Homebrew tap management to the `brew` backend, matching the existing repo support for `dnf` and `flatpak`.

### Usage

In a group file, declare taps under `brew.repos`:

```toml
brew = {
  repos = [
    "ublue-os/tap",
  ],
  packages = ["aurora-wallpapers"]
}
```

`metapac sync` will tap and trust any missing repos. `metapac clean` will untap and untrust any repos not listed. `metapac unmanaged` will report taps that are not declared in any group file.

### Implementation

- `get_installed_repos()` now runs `brew tap` to discover existing taps.
- `add_repos()` runs `brew tap <tap>` and `brew trust --tap <tap>`. Trusting is required because recent Homebrew versions refuse to load casks from untrusted taps.
- `remove_repos()` runs `brew untap <tap>` and `brew untrust --tap <tap>` to keep trust state in sync.

### Dependencies

This PR depends on #234 (which you just merged), which fixes `metapac clean` so packages are removed before repos. Without that fix, `brew untap` fails because Homebrew refuses to untap a tap that still contains installed casks or formulae:

```text
Error: Refusing to untap ublue-os/tap because it contains the following installed casks:
ublue-os/tap/aurora-wallpapers
```
### Testing

Tested locally with `cargo run --`:

1. `metapac unmanaged` correctly detected a tap not declared in group files.
2. Added a temporary group file with `ublue-os/tap` and `aurora-wallpapers`. `metapac sync --no-confirm` tapped, trusted, and installed successfully.
3. Removed the temporary group file. `metapac clean --no-confirm` uninstalled the package first, then untapped and untrusted the tap.

### Checklist

- [x] `cargo check` passes
- [x] `cargo fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes after #234 is merged
- [x] README group file example updated
- [x] Manual end-to-end test completed
