### PR TITLE
fix(cargo): Don't use binstall when git option is present

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ locked = false
 # Whether to use `cargo-binstall` instead of `cargo install` for installing packages.
 # When `true`, metapac will use `cargo binstall --no-confirm` instead of `cargo install`.
 # This can be faster for installing packages as it downloads pre-built binaries.
+# Can be overridden per-package with the `binstall` package option.
 # Default: false
 binstall = false
 
@@ -475,6 +476,7 @@ cargo = {
       name = "package2",
       options = {
         git = "https://github.com/ripytide/metapac",
+        binstall = true,
         all_features = true,
         no_default_features = false,
         features = [

--- a/README.md
+++ b/README.md
@@ -343,10 +343,9 @@ package_manager = "paru"
 # Default: false
 locked = false
 
-# Whether to use `cargo-binstall` instead of `cargo install` for installing packages.
-# When `true`, metapac will use `cargo binstall --no-confirm` instead of `cargo install`.
-# This can be faster for installing packages as it downloads pre-built binaries.
-# Can be overridden per-package with the `binstall` package option.
+# Whether to default to installing cargo packages with `cargo-binstall`,
+# When `true`, metapac will use `cargo binstall --no-confirm` instead of
+# `cargo install` to install packages.
 # Default: false
 binstall = false
 
@@ -476,13 +475,13 @@ cargo = {
       name = "package2",
       options = {
         git = "https://github.com/ripytide/metapac",
-        binstall = true,
         all_features = true,
         no_default_features = false,
         features = [
           "feature1",
         ],
-        locked = true
+        locked = true,
+        binstall = true
       }
     },
   ]

--- a/src/backends/cargo.rs
+++ b/src/backends/cargo.rs
@@ -89,7 +89,32 @@ impl Backend for Cargo {
         config: &Self::Config,
     ) -> Result<()> {
         for (package, options) in packages {
-            run_command(install_args(package, options, config), Perms::Same)?;
+            run_command(
+                ["cargo"]
+                    .into_iter()
+                    .chain(if options.binstall.unwrap_or(config.binstall) {
+                        vec!["binstall", "--no-confirm"]
+                    } else {
+                        vec!["install"]
+                    })
+                    .chain(
+                        options
+                            .locked
+                            .unwrap_or(config.locked)
+                            .then_some("--locked"),
+                    )
+                    .chain(options.git.is_some().then_some("--git"))
+                    .chain(options.git.as_deref())
+                    .chain((options.all_features == Some(true)).then_some("--all_features"))
+                    .chain(
+                        (options.no_default_features == Some(true))
+                            .then_some("--no-default-features"),
+                    )
+                    .chain((!options.features.is_empty()).then_some("--features"))
+                    .chain(options.features.iter().map(String::as_str))
+                    .chain([package.as_str()]),
+                Perms::Same,
+            )?;
         }
 
         Ok(())
@@ -185,34 +210,6 @@ impl Backend for Cargo {
     }
 }
 
-fn install_args<'a>(
-    package: &'a str,
-    options: &'a CargoPackageOptions,
-    config: &'a CargoConfig,
-) -> Vec<&'a str> {
-    ["cargo"]
-        .into_iter()
-        .chain(if options.binstall.unwrap_or(config.binstall) {
-            vec!["binstall", "--no-confirm"]
-        } else {
-            vec!["install"]
-        })
-        .chain(
-            options
-                .locked
-                .unwrap_or(config.locked)
-                .then_some("--locked"),
-        )
-        .chain(options.git.is_some().then_some("--git"))
-        .chain(options.git.as_deref())
-        .chain((options.all_features == Some(true)).then_some("--all_features"))
-        .chain((options.no_default_features == Some(true)).then_some("--no-default-features"))
-        .chain((!options.features.is_empty()).then_some("--features"))
-        .chain(options.features.iter().map(String::as_str))
-        .chain([package])
-        .collect()
-}
-
 fn extract_packages(contents: &str) -> Result<BTreeMap<String, CargoPackageOptions>> {
     let toml: toml::Table =
         toml::from_str(contents).wrap_err("parsing TOML from .crates.toml file")?;
@@ -260,60 +257,4 @@ fn extract_packages(contents: &str) -> Result<BTreeMap<String, CargoPackageOptio
     }
 
     Ok(packages)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn config(binstall: bool) -> CargoConfig {
-        CargoConfig {
-            locked: false,
-            binstall,
-        }
-    }
-
-    #[test]
-    fn per_package_binstall_false_overrides_enabled_config() {
-        let config = config(true);
-        let options = CargoPackageOptions {
-            binstall: Some(false),
-            ..CargoPackageOptions::default()
-        };
-        let args = install_args("foo", &options, &config);
-
-        assert_eq!(args[1], "install");
-    }
-
-    #[test]
-    fn per_package_binstall_true_overrides_disabled_config() {
-        let config = config(false);
-        let options = CargoPackageOptions {
-            binstall: Some(true),
-            ..CargoPackageOptions::default()
-        };
-        let args = install_args("foo", &options, &config);
-
-        assert_eq!(args[1], "binstall");
-        assert_eq!(args[2], "--no-confirm");
-    }
-
-    #[test]
-    fn defaults_to_config_binstall_when_not_specified() {
-        let config = config(true);
-        let options = CargoPackageOptions::default();
-        let args = install_args("foo", &options, &config);
-
-        assert_eq!(args[1], "binstall");
-        assert_eq!(args[2], "--no-confirm");
-    }
-
-    #[test]
-    fn does_not_use_binstall_when_disabled() {
-        let config = config(false);
-        let options = CargoPackageOptions::default();
-        let args = install_args("foo", &options, &config);
-
-        assert_eq!(args[1], "install");
-    }
 }

--- a/src/backends/cargo.rs
+++ b/src/backends/cargo.rs
@@ -35,6 +35,8 @@ pub struct CargoPackageOptions {
     features: Vec<String>,
     #[serde(default)]
     locked: Option<bool>,
+    #[serde(default)]
+    binstall: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -188,11 +190,9 @@ fn install_args<'a>(
     options: &'a CargoPackageOptions,
     config: &'a CargoConfig,
 ) -> Vec<&'a str> {
-    // binstall does not support installing from git repositories, so fall back
-    // to a regular cargo install when the git option is enabled.
     ["cargo"]
         .into_iter()
-        .chain(if config.binstall && options.git.is_none() {
+        .chain(if options.binstall.unwrap_or(config.binstall) {
             vec!["binstall", "--no-confirm"]
         } else {
             vec!["install"]
@@ -253,6 +253,7 @@ fn extract_packages(contents: &str) -> Result<BTreeMap<String, CargoPackageOptio
                     no_default_features: None,
                     features: Vec::new(),
                     locked: None,
+                    binstall: None,
                 },
             );
         }
@@ -272,31 +273,47 @@ mod tests {
         }
     }
 
-    fn git_options() -> CargoPackageOptions {
-        CargoPackageOptions {
-            git: Some("https://example.com/repo".to_string()),
-            ..CargoPackageOptions::default()
-        }
-    }
-
     #[test]
-    fn falls_back_to_cargo_install_for_git_packages_when_binstall_is_enabled() {
+    fn per_package_binstall_false_overrides_enabled_config() {
         let config = config(true);
-        let options = git_options();
+        let options = CargoPackageOptions {
+            binstall: Some(false),
+            ..CargoPackageOptions::default()
+        };
         let args = install_args("foo", &options, &config);
 
         assert_eq!(args[1], "install");
-        assert!(args.contains(&"--git"));
-        assert_eq!(args.last(), Some(&"foo"));
     }
 
     #[test]
-    fn uses_binstall_for_packages_without_git() {
+    fn per_package_binstall_true_overrides_disabled_config() {
+        let config = config(false);
+        let options = CargoPackageOptions {
+            binstall: Some(true),
+            ..CargoPackageOptions::default()
+        };
+        let args = install_args("foo", &options, &config);
+
+        assert_eq!(args[1], "binstall");
+        assert_eq!(args[2], "--no-confirm");
+    }
+
+    #[test]
+    fn defaults_to_config_binstall_when_not_specified() {
         let config = config(true);
         let options = CargoPackageOptions::default();
         let args = install_args("foo", &options, &config);
 
         assert_eq!(args[1], "binstall");
         assert_eq!(args[2], "--no-confirm");
+    }
+
+    #[test]
+    fn does_not_use_binstall_when_disabled() {
+        let config = config(false);
+        let options = CargoPackageOptions::default();
+        let args = install_args("foo", &options, &config);
+
+        assert_eq!(args[1], "install");
     }
 }

--- a/src/backends/cargo.rs
+++ b/src/backends/cargo.rs
@@ -87,32 +87,7 @@ impl Backend for Cargo {
         config: &Self::Config,
     ) -> Result<()> {
         for (package, options) in packages {
-            run_command(
-                ["cargo"]
-                    .into_iter()
-                    .chain(if config.binstall {
-                        vec!["binstall", "--no-confirm"]
-                    } else {
-                        vec!["install"]
-                    })
-                    .chain(
-                        options
-                            .locked
-                            .unwrap_or(config.locked)
-                            .then_some("--locked"),
-                    )
-                    .chain(options.git.is_some().then_some("--git"))
-                    .chain(options.git.as_deref())
-                    .chain((options.all_features == Some(true)).then_some("--all_features"))
-                    .chain(
-                        (options.no_default_features == Some(true))
-                            .then_some("--no-default-features"),
-                    )
-                    .chain((!options.features.is_empty()).then_some("--features"))
-                    .chain(options.features.iter().map(String::as_str))
-                    .chain([package.as_str()]),
-                Perms::Same,
-            )?;
+            run_command(install_args(package, options, config), Perms::Same)?;
         }
 
         Ok(())
@@ -208,6 +183,36 @@ impl Backend for Cargo {
     }
 }
 
+fn install_args<'a>(
+    package: &'a str,
+    options: &'a CargoPackageOptions,
+    config: &'a CargoConfig,
+) -> Vec<&'a str> {
+    // binstall does not support installing from git repositories, so fall back
+    // to a regular cargo install when the git option is enabled.
+    ["cargo"]
+        .into_iter()
+        .chain(if config.binstall && options.git.is_none() {
+            vec!["binstall", "--no-confirm"]
+        } else {
+            vec!["install"]
+        })
+        .chain(
+            options
+                .locked
+                .unwrap_or(config.locked)
+                .then_some("--locked"),
+        )
+        .chain(options.git.is_some().then_some("--git"))
+        .chain(options.git.as_deref())
+        .chain((options.all_features == Some(true)).then_some("--all_features"))
+        .chain((options.no_default_features == Some(true)).then_some("--no-default-features"))
+        .chain((!options.features.is_empty()).then_some("--features"))
+        .chain(options.features.iter().map(String::as_str))
+        .chain([package])
+        .collect()
+}
+
 fn extract_packages(contents: &str) -> Result<BTreeMap<String, CargoPackageOptions>> {
     let toml: toml::Table =
         toml::from_str(contents).wrap_err("parsing TOML from .crates.toml file")?;
@@ -254,4 +259,44 @@ fn extract_packages(contents: &str) -> Result<BTreeMap<String, CargoPackageOptio
     }
 
     Ok(packages)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(binstall: bool) -> CargoConfig {
+        CargoConfig {
+            locked: false,
+            binstall,
+        }
+    }
+
+    fn git_options() -> CargoPackageOptions {
+        CargoPackageOptions {
+            git: Some("https://example.com/repo".to_string()),
+            ..CargoPackageOptions::default()
+        }
+    }
+
+    #[test]
+    fn falls_back_to_cargo_install_for_git_packages_when_binstall_is_enabled() {
+        let config = config(true);
+        let options = git_options();
+        let args = install_args("foo", &options, &config);
+
+        assert_eq!(args[1], "install");
+        assert!(args.contains(&"--git"));
+        assert_eq!(args.last(), Some(&"foo"));
+    }
+
+    #[test]
+    fn uses_binstall_for_packages_without_git() {
+        let config = config(true);
+        let options = CargoPackageOptions::default();
+        let args = install_args("foo", &options, &config);
+
+        assert_eq!(args[1], "binstall");
+        assert_eq!(args[2], "--no-confirm");
+    }
 }


### PR DESCRIPTION
When using the git option, for example:
```toml
cargo = { packages = [
  { name = "mdisplay", options = { git = "https://github.com/ernestoCruz05/mdisplay" } },
] }
``` 
when `binstall = true`, the `cargo binstall` process errors with
```
error: could not find `mdisplay` in registry `crates-io` with version `=0.2.0`
ERROR Cargo errored! ExitStatus(unix_wait_status(25856))
ERROR Fatal error:
  × For crate mdisplay: subprocess /usr/bin/cargo install mdisplay --version 0.2.0 --root /home/joe/.cargo errored with exit status: 101
  ╰─▶ subprocess /usr/bin/cargo install mdisplay --version 0.2.0 --root /home/joe/.cargo errored with exit status: 101
  ```
  because the crate does not exist on crates.io. This PR makes the cargo backend always fall back to regular `cargo install` when the git option is present, and adds a unit test. 