### PR TITLE
feat(zypper): add repository discovery, add, and remove support

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,28 @@ Standard usage.
 
 ### zypper
 
-Standard usage.
+Zypper repositories use their alias as the repo name. You can add a repository
+using its URL or a `.repo` file URL. The output from `metapac unmanaged` can be
+copied into a group file and includes the GPG key when one is needed.
+
+```toml
+zypper = {
+  repos = [
+    {
+      name = "packman",
+      options = {
+        url = "https://ftp.gwdg.de/pub/linux/misc/packman/suse/$releasever/"
+      }
+    },
+    {
+      name = "brave-browser",
+      options = {
+        url = "https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo"
+      }
+    }
+  ]
+}
+```
 
 ## Config
 

--- a/src/backends/zypper.rs
+++ b/src/backends/zypper.rs
@@ -2,6 +2,7 @@ use color_eyre::Result;
 use color_eyre::eyre::eyre;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
+use std::io::Write;
 
 use crate::cmd::{run_command, run_command_for_stdout};
 use crate::prelude::*;
@@ -22,7 +23,70 @@ pub struct ZypperPackageOptions {}
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct ZypperRepoOptions {}
+pub struct ZypperRepoOptions {
+    pub url: String,
+    #[serde(default)]
+    pub gpgkey: Option<String>,
+}
+
+fn is_user_installed(line: &str) -> bool {
+    matches!(line.split('|').next().map(str::trim), Some("i+" | "il"))
+}
+
+fn parse_repos(stdout: &str) -> Result<BTreeMap<String, ZypperRepoOptions>> {
+    let mut repos = BTreeMap::new();
+    let mut alias = None;
+    let mut url = None;
+    let mut gpgkey = None;
+
+    let add_repo = |repos: &mut BTreeMap<_, _>,
+                    alias: &mut Option<String>,
+                    url: &mut Option<String>,
+                    gpgkey: &mut Option<String>|
+     -> Result<()> {
+        if let Some(alias) = alias.take() {
+            let url = url.take().ok_or(eyre!("unexpected zypper repo output"))?;
+            repos.insert(
+                alias,
+                ZypperRepoOptions {
+                    url,
+                    gpgkey: gpgkey.take(),
+                },
+            );
+        }
+        Ok(())
+    };
+
+    for line in stdout.lines().map(str::trim) {
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        if let Some(section) = line
+            .strip_prefix('[')
+            .and_then(|line| line.strip_suffix(']'))
+        {
+            add_repo(&mut repos, &mut alias, &mut url, &mut gpgkey)?;
+            if section.is_empty() {
+                return Err(eyre!("unexpected zypper repo output"));
+            }
+            alias = Some(section.to_string());
+            continue;
+        }
+
+        let (key, value) = line
+            .split_once('=')
+            .ok_or(eyre!("unexpected zypper repo output"))?;
+        match key.trim() {
+            "baseurl" => url = Some(value.trim().to_string()),
+            "gpgkey" => gpgkey = Some(value.trim().to_string()),
+            _ => {}
+        }
+    }
+
+    add_repo(&mut repos, &mut alias, &mut url, &mut gpgkey)?;
+    Ok(repos)
+}
 
 impl Backend for Zypper {
     type Config = ZypperConfig;
@@ -56,7 +120,7 @@ impl Backend for Zypper {
 
         stdout
             .lines()
-            .filter(|line| line.starts_with("i+"))
+            .filter(|line| is_user_installed(line))
             .map(|line| -> Result<(String, Self::PackageOptions)> {
                 let mut parts = line.split('|');
                 let package = parts
@@ -148,30 +212,156 @@ impl Backend for Zypper {
     }
 
     fn get_installed_repos(_: &Self::Config) -> Result<BTreeMap<String, Self::RepoOptions>> {
-        Ok(BTreeMap::new())
+        let repos = run_command_for_stdout(
+            ["zypper", "repos", "--show-enabled-only", "--export", "-"],
+            Perms::Same,
+            StdErr::Show,
+        )?;
+
+        Ok(parse_repos(&repos)?
+            .into_iter()
+            .filter(|(alias, _)| !alias.starts_with("openSUSE:"))
+            .collect())
     }
 
     fn add_repos(
         repos: &BTreeMap<String, Self::RepoOptions>,
-        _: bool,
+        no_confirm: bool,
         _: &Self::Config,
     ) -> Result<()> {
-        if repos.is_empty() {
-            Ok(())
-        } else {
-            Err(eyre!("unimplemented"))
+        for (alias, options) in repos {
+            if options.url.is_empty() {
+                return Err(eyre!("zypper repo {alias:?} has an empty url"));
+            }
+
+            // `zypper addrepo` accepts either a URL plus alias or a `.repo` file, but not
+            // individual settings like `gpgkey`. When a gpgkey is present, write a temporary
+            // `.repo` definition so Zypper can add the repository in one step.
+            let repo_file = options
+                .gpgkey
+                .as_ref()
+                .map(|gpgkey| {
+                    let mut file = tempfile::NamedTempFile::new()?;
+                    writeln!(file, "[{alias}]")?;
+                    writeln!(file, "name={alias}")?;
+                    writeln!(file, "enabled=1")?;
+                    writeln!(file, "autorefresh=1")?;
+                    writeln!(file, "baseurl={}", options.url)?;
+                    writeln!(file, "type=rpm-md")?;
+                    writeln!(file, "gpgcheck=1")?;
+                    writeln!(file, "gpgkey={gpgkey}")?;
+                    file.flush()?;
+                    Ok::<_, color_eyre::eyre::Report>(file)
+                })
+                .transpose()?;
+
+            let url = if let Some(file) = repo_file.as_ref() {
+                file.path()
+                    .to_str()
+                    .ok_or(eyre!("temporary zypper repo file path is not valid UTF-8"))?
+            } else {
+                options.url.as_str()
+            };
+
+            let repo_file_url = repo_file.is_some()
+                || std::path::Path::new(&options.url)
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("repo"));
+            let mut args = vec!["zypper"];
+            if no_confirm {
+                args.push("--non-interactive");
+            }
+            if repo_file_url {
+                args.extend(["addrepo", "--repo"]);
+                args.push(url);
+            } else {
+                args.extend(["addrepo", "--refresh"]);
+                args.extend([url, alias.as_str()]);
+            }
+
+            run_command(args, Perms::Sudo)?;
         }
+
+        Ok(())
     }
 
-    fn remove_repos(repos: &BTreeSet<String>, _: bool, _: &Self::Config) -> Result<()> {
-        if repos.is_empty() {
-            Ok(())
-        } else {
-            Err(eyre!("unimplemented"))
+    fn remove_repos(repos: &BTreeSet<String>, no_confirm: bool, _: &Self::Config) -> Result<()> {
+        for alias in repos {
+            run_command(
+                ["zypper"]
+                    .into_iter()
+                    .chain(no_confirm.then_some("--non-interactive"))
+                    .chain(["removerepo", alias.as_str()]),
+                Perms::Sudo,
+            )?;
         }
+
+        Ok(())
     }
 
     fn version(_: &Self::Config) -> Result<String> {
         run_command_for_stdout(["zypper", "--version"], Perms::Same, StdErr::Show)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_user_installed, parse_repos};
+
+    #[test]
+    fn parses_exported_repo_output() {
+        let repos = parse_repos(
+            "[packman]\n\
+             name=Packman\n\
+             enabled=1\n\
+             baseurl=https://ftp.gwdg.de/pub/linux/misc/packman/suse/$releasever/\n\
+             gpgcheck=1\n\
+             \n\
+             [brave-browser]\n\
+             name=Brave Browser\n\
+             enabled=1\n\
+             baseurl=https://brave-browser-rpm-release.s3.brave.com/x86_64\n\
+             gpgcheck=1\n\
+             gpgkey=https://brave-browser-rpm-release.s3.brave.com/brave-core.asc\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            repos["packman"].url,
+            "https://ftp.gwdg.de/pub/linux/misc/packman/suse/$releasever/"
+        );
+        assert_eq!(
+            repos["brave-browser"].url,
+            "https://brave-browser-rpm-release.s3.brave.com/x86_64"
+        );
+        assert_eq!(
+            repos["brave-browser"].gpgkey.as_deref(),
+            Some("https://brave-browser-rpm-release.s3.brave.com/brave-core.asc")
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_exported_repo_output() {
+        assert!(parse_repos("[packman]\nname=Packman\n").is_err());
+    }
+
+    #[test]
+    fn recognizes_locked_userinstalled_packages() {
+        let packages = "il | @System | kernel-default | 7.1.5-1.1 | x86_64\n\
+                        vl | repo-oss | kernel-default | 7.1.6-1.1 | x86_64\n";
+
+        let installed = packages
+            .lines()
+            .filter(|line| is_user_installed(line))
+            .map(|line| {
+                line.split('|')
+                    .nth(2)
+                    .expect("package column")
+                    .trim()
+                    .to_string()
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(installed, ["kernel-default"]);
     }
 }


### PR DESCRIPTION
# Add Zypper repository support

## Summary

Implements full repository lifecycle support for the Zypper backend. Previously `metapac` only listed Zypper packages; it could not discover, add, or remove Zypper repositories. This change makes Zypper behave consistently with other backend repository implementations while respecting Zypper-specific conventions such as `$releasever`/`$basearch` variables and GPG key handling.

## Changes

- `src/backends/zypper.rs`
  
  - Repository discovery now uses `zypper repos --show-enabled-only --export -`, which returns INI-style `.repo` definitions.
  - Discovered repositories are keyed by their Zypper alias.
  - Default `openSUSE:*` repositories are filtered out of unmanaged output.
  - `ZypperRepoOptions` gained an optional `gpgkey` field so exported signing-key configuration is preserved.
  - `add_repos` now supports two forms:
    - Direct `.repo` file URLs (e.g. Brave's official `brave-browser.repo`).
    - Regular `baseurl` repositories with an explicit `gpgkey`, which are recreated via a temporary `.repo` definition.
  - `remove_repos` removes repositories by alias using `zypper removerepo`.
  - Installed-package parsing now recognises the `il` (locked but explicitly installed) status in addition to `i+`, preventing locked packages such as `kernel-default` from appearing as missing.
- `README.md`
  
  - Replaced the Zypper "Standard usage." section with repository documentation and a PackMan/Brave example.
  - Removed a misleading `$releasever` paragraph.
- Tests
  
  - Added parser tests for exported repository definitions including `gpgkey` extraction.
  - Added a regression test for locked user-installed packages.

## Example group file

```toml
zypper = {
  repos = [
    {
      name = "packman",
      options = {
        url = "https://ftp.fau.de/packman/suse/openSUSE_Tumbleweed/"
      }
    },
    {
      name = "brave-browser",
      options = {
        url = "https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo"
      }
    }
  ],
  packages = [
    "brave-browser",
  ]
}
```

## Notes for reviewers

- Discovery intentionally filters aliases starting with `openSUSE:` because these are distribution repositories managed by the `openSUSE` service. This is conceptually similar to DNF only listing COPR repos with `dnf copr list`; Zypper has no equivalent "third-party only" command, so a prefix filter is used to avoid cluttering unmanaged output with default repos.
- `--non-interactive` is only passed when `no_confirm` is set, matching existing backend conventions. Interactive `metapac sync` therefore lets Zypper prompt for new GPG keys.
- For discovered repositories with a `gpgkey`, metapac writes a temporary `.repo` file and passes that to `zypper addrepo`, because the `addrepo` command accepts either a plain URL plus alias or a full `.repo` file, not individual settings like `gpgkey`.